### PR TITLE
Bump rails from 6.1.3 to 6.1.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.0.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.1.3'
+gem 'rails', '~> 6.1.3.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server


### PR DESCRIPTION
Bump rails from 6.1.3 to 6.1.3.2

Version 6.1.3 is affected by the license change issue of mimemagic.
Rails released the fix quickly in 6.1.3.1
Details: https://github.com/rails/rails/issues/41757

Currently "bundle install" throws the mimemagic related error described above.
This commit is solving this error.